### PR TITLE
dependabot/gradle/androidx.compose.material3-material3-1.3.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,7 +32,7 @@ rtlViewpager = "940f12724f"
 composeActivity = "1.9.3"
 compose = "1.7.6"
 composeCompiler = "1.5.15"
-composeMaterial3 = "1.3.1"
+composeMaterial3 = "1.3.2"
 #Glide
 glide = "4.16.0"
 glideCompose = "1.0.0-beta01"


### PR DESCRIPTION
Bumps androidx.compose.material3:material3 from 1.3.1 to 1.3.2.

---
updated-dependencies:
- dependency-name: androidx.compose.material3:material3 dependency-version: 1.3.2 dependency-type: direct:production update-type: version-update:semver-patch ...

<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [ ] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
- Updated colors
- Update strings
- Added documentation

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, consider including screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- Before:
- After:

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes FossifyOrg/AppRepo" so that GitHub closes them when this PR is merged (note that each "Fixes #" should be in its own item). For Commons, it should always be in a format like "Fixes FossifyOrg/AppRepo#123" -->
- Fixes FossifyOrg/

#### Relies on the following changes
<!-- Delete this if it doesn't apply to your PR. -->
- 

#### Acknowledgement
- [ ] I read the [contribution guidelines](https://github.com/FossifyOrg/Commons/blob/master/CONTRIBUTING.md).
