### PR TITLE
chore(deps): bump androidx.core:core-ktx from 1.13.1 to 1.16.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ androidx-constraintlayout = "2.2.0"
 androidx-documentfile = "1.0.1"
 androidx-biometricKtx = "1.2.0-alpha05"
 androidx-exifinterface = "1.3.7"
-androidx-coreKtx = "1.13.1"
+androidx-coreKtx = "1.16.0"
 androidx-appcompat = "1.7.0"
 androidx-swiperefreshlayout = "1.1.0"
 #Material


### PR DESCRIPTION
Bumps androidx.core:core-ktx from 1.13.1 to 1.16.0.

---
updated-dependencies:
- dependency-name: androidx.core:core-ktx dependency-version: 1.16.0 dependency-type: direct:production update-type: version-update:semver-minor ...

<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [ ] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
- Updated colors
- Update strings
- Added documentation

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, consider including screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- Before:
- After:

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes FossifyOrg/AppRepo" so that GitHub closes them when this PR is merged (note that each "Fixes #" should be in its own item). For Commons, it should always be in a format like "Fixes FossifyOrg/AppRepo#123" -->
- Fixes FossifyOrg/

#### Relies on the following changes
<!-- Delete this if it doesn't apply to your PR. -->
- 

#### Acknowledgement
- [ ] I read the [contribution guidelines](https://github.com/FossifyOrg/Commons/blob/master/CONTRIBUTING.md).
